### PR TITLE
Manifest v3

### DIFF
--- a/background.js
+++ b/background.js
@@ -31,3 +31,27 @@ chrome.browserAction.onClicked.addListener(function(tab) {
   var manager_url = chrome.extension.getURL("manager.html");
   focusOrCreateTab(manager_url);
 });*/
+
+chrome.runtime.onStartup.addListener(function () {
+  createOffscreen();
+});
+
+chrome.runtime.onInstalled.addListener(function () {
+  createOffscreen();
+});
+
+// Use offscreen API to keep service worker alive
+// Ref: https://stackoverflow.com/questions/66618136/persistent-service-worker-in-chrome-extension/66618269#66618269
+// create the offscreen document if it doesn't already exist
+async function createOffscreen() {
+  if (await chrome.offscreen.hasDocument?.()) return;
+  await chrome.offscreen.createDocument({
+    url: 'offscreen.html',
+    reasons: ['BLOBS'],
+    justification: 'keep service worker running',
+  });
+}
+// a message from an offscreen document every 20 second resets the inactivity timer
+chrome.runtime.onMessage.addListener(msg => {
+  if (msg.keepAlive) console.log('keepAlive');
+});

--- a/manifest.json
+++ b/manifest.json
@@ -2,15 +2,16 @@
   "name" : "Cookie Profile Switcher",
   "version" : "1.3.3",
   "description" : "Store & Manage multiple cookie profiles per domain.",
-  "permissions": [ "cookies", "tabs", "http://*/*", "https://*/*", "storage" ],
+  "permissions": [ "cookies", "tabs", "storage", "scripting", "offscreen" ],
+  "host_permissions": [ "<all_urls>" ],
   "icons": { "16": "cookie.png", "48": "cookie.png", "128": "cookie.png" },
   "options_page": "options.html",
-  "browser_action": {
+  "action": {
     "default_icon": "cookie.png",
-	"default_popup": "profiles.html"
+	  "default_popup": "profiles.html"
   },
   "background": {
-    "scripts": ["background.js", "scripts/jquery-3.1.1.min.js"]
+    "service_worker": "background.js"
   },
-  "manifest_version": 2
+  "manifest_version": 3
 }

--- a/offscreen.html
+++ b/offscreen.html
@@ -1,0 +1,1 @@
+<script src="offscreen.js"></script>

--- a/offscreen.js
+++ b/offscreen.js
@@ -1,0 +1,4 @@
+// send a message every 20 sec to service worker
+setInterval(() => {
+    chrome.runtime.sendMessage({ keepAlive: true });
+}, 20000);

--- a/options.html
+++ b/options.html
@@ -17,7 +17,7 @@
 	<script src="options.js"></script>
 </head>
 
-<body onbeforeunload="">
+<body>
 	<div class="container">
 		<h1><img src="cookie.png" alt="" style="width: 64px; height: 64px;" /> Cookie Profile Switcher</h1>
 		

--- a/profiles.js
+++ b/profiles.js
@@ -330,9 +330,16 @@ function changeProfile(event){
 			
 			chrome.tabs.query({active: true, currentWindow: true}, function (arrayOfTabs) {
 				var code = 'window.location.reload();';
-				chrome.tabs.executeScript(arrayOfTabs[0].id, {code: code});
+				
+				// manifest v2
+				// chrome.tabs.executeScript(arrayOfTabs[0].id, {code: code});
+
+				// manifest v3
+				chrome.scripting.executeScript({
+					target: {tabId: arrayOfTabs[0].id},
+					func: ()=>{window.location.reload();}
+				});
 			});
-			
 		});
 		
 	});

--- a/scripts/browser-functions.js
+++ b/scripts/browser-functions.js
@@ -47,7 +47,7 @@ var extension = {};
 		
 		// Chrome
 		else if(IS_CHROME) {
-			var details = chrome.app.getDetails();
+			var details = chrome.runtime.getManifest();
 			extension._version = details.version;
 		}
 		return extension._version;


### PR DESCRIPTION
Because Chrome is stopping supporting Manifest V2, this PR aims at transiting this project to Manifest V3
>As Manifest V3 approaches full feature parity with Manifest V2, we'll be progressively phasing out Manifest V2. This page specifies the timetable for this deprecation and describes the meaning of each milestone.

Ref: [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/migrating/mv2-sunset/)

